### PR TITLE
更新API文件

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,1570 +1,2801 @@
 {
-    "openapi": "3.0.1",
-    "info": {
-        "title": "NKUST API",
-        "description": "NKUST-API-完善計畫  [Github](https://github.com/NKUST-ITC/AP-API)",
-        "contact": {
-            "email": "nkust.itc@gmail.com"
-        },
-        "license": {
-            "name": "MIT License",
-            "url": "https://github.com/NKUST-ITC/AP-API/blob/master/LICENSE.md"
-        },
-        "version": "3.0.0"
+  "openapi": "3.0.1",
+  "info": {
+    "title": "NKUST API",
+    "description": "NKUST-API-完善計畫  [Github](https://github.com/NKUST-ITC/AP-API)",
+    "contact": {
+      "email": "nkust.itc@gmail.com"
     },
-    "servers": [
-        {
-            "url": "https://nkust-ap-api.rainvisitor.me:2087/latest"
-        }
-    ],
-    "tags": [
-        {
-            "name": "Authentication",
-            "description": "About authentication"
-        },
-        {
-            "name": "Server",
-            "description": "Some server info"
-        },
-        {
-            "name": "User",
-            "description": "Everything about user"
-        },
-        {
-            "name": "Bus",
-            "description": "Everything about bus"
-        },
-        {
-            "name": "News",
-            "description": "Everything about news"
-        },
-        {
-            "name": "Leave",
-            "description": "Everything about leave"
-        },
-        {
-            "name": "Library",
-            "description": "Everything about library"
-        }
-    ],
-    "paths": {
-        "/auth/login": {
-            "post": {
-                "tags": [
-                    "Authentication"
-                ],
-                "summary": "get a new token",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/User"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "login sucess",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Auth"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request"
-                    },
-                    "401": {
-                        "description": "Username or password is incorrect"
-                    },
-                    "504": {
-                        "description": "All school server is not alive"
-                    }
-                }
-            }
-        },
-        "/auth/logout": {
-            "post": {
-                "tags": [
-                    "Authentication"
-                ],
-                "summary": "delete all token",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/User"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "205": {
-                        "description": "Logout sucess and client should reset content"
-                    },
-                    "400": {
-                        "description": "Bad Request"
-                    },
-                    "401": {
-                        "description": "Username or password is incorrect"
-                    }
-                }
-            }
-        },
-        "/server/info": {
-            "get": {
-                "tags": [
-                    "Server"
-                ],
-                "summary": "get server status (update every 10 minutes)",
-                "responses": {
-                    "200": {
-                        "description": "return server status",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ServerInfo"
-                                }
-                            }
-                        }
-                    },
-                    "503": {
-                        "description": "Upstream server is timeout"
-                    },
-                    "504": {
-                        "description": "Upstream server is not alive"
-                    }
-                }
-            }
-        },
-        "/news/announcements": {
-            "get": {
-                "tags": [
-                    "News"
-                ],
-                "summary": "get first announcements",
-                "responses": {
-                    "200": {
-                        "description": "return first news",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/News"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Page not found"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    }
-                }
-            }
-        },
-        "/news/announcements/{id}": {
-            "get": {
-                "tags": [
-                    "News"
-                ],
-                "summary": "get announcement by id",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "description": "id or news",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "return news by id",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/News"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Page not found"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    }
-                }
-            }
-        },
-        "/news/announcements/all": {
-            "get": {
-                "tags": [
-                    "News"
-                ],
-                "summary": "get all announcements",
-                "responses": {
-                    "200": {
-                        "description": "return all news",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "id": {
-                                                "type": "integer",
-                                                "description": "id"
-                                            },
-                                            "nextid": {
-                                                "type": "integer",
-                                                "description": "next news id"
-                                            },
-                                            "lastId": {
-                                                "type": "integer"
-                                            },
-                                            "title": {
-                                                "type": "string",
-                                                "description": "title"
-                                            },
-                                            "publishedTime": {
-                                                "type": "string",
-                                                "description": "publish time"
-                                            },
-                                            "url": {
-                                                "type": "string",
-                                                "description": "news url"
-                                            },
-                                            "imgUrl": {
-                                                "type": "string",
-                                                "description": "image url"
-                                            },
-                                            "description": {
-                                                "type": "string",
-                                                "description": "news description"
-                                            }
-                                        }
-                                    }
-                                },
-                                "example": [
-                                    {
-                                        "title": "高科校務通IOS版 回歸",
-                                        "id": 1,
-                                        "nextId": 2,
-                                        "lastId": 2,
-                                        "imgUrl": "https://i.imgur.com/faSwvRv.jpg",
-                                        "url": "https://nkustap.page.link/bCK1",
-                                        "description": "重新推出 IOS 版本 高科校務通 此版本還在測試中 歡迎同學私訊粉專意見回饋\t",
-                                        "publishedTime": "2019-03-16T20:16:04+08:00"
-                                    },
-                                    {
-                                        "title": "宿舍直達高鐵站專車",
-                                        "id": 2,
-                                        "nextId": -1,
-                                        "lastId": 2,
-                                        "imgUrl": "https://i.imgur.com/wwxD4Xa.png",
-                                        "url": "",
-                                        "description": "從燕巢宿舍直接發車，不用再走到公車站排隊 人數達25人即發車，一人只要30元喔",
-                                        "publishedTime": "2019-03-16T20:16:04+08:00"
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Page not found"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    }
-                }
-            }
-        },
-        "/news/school": {
-            "get": {
-                "tags": [
-                    "News"
-                ],
-                "summary": "get news",
-                "responses": {
-                    "200": {
-                        "description": "return school news",
-                        "content": {
-                            "application/json": {
-                                "example": {
-                                    "page": 1,
-                                    "notification": [
-                                        {
-                                            "link": "http://kuasnews.kuas.edu.tw/files/13-1018-70766-1.php",
-                                            "info": {
-                                                "id": "1",
-                                                "title": "2019年高科大高雄亮點日語導覽競賽",
-                                                "department": "觀光系",
-                                                "date": "2019-03-13"
-                                            }
-                                        },
-                                        {
-                                            "link": "http://gec.kuas.edu.tw/files/13-1012-70765-1.php",
-                                            "info": {
-                                                "id": "2",
-                                                "title": "快來拿獎金!!!第22屆優質通識課程學生學習檔案e化徵選活動~",
-                                                "department": "通識中心",
-                                                "date": "2019-03-13"
-                                            }
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Page not found"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    }
-                }
-            }
-        },
-        "/user/info": {
-            "get": {
-                "tags": [
-                    "User"
-                ],
-                "summary": "get user's info",
-                "security": [
-                    {
-                        "JSON-Web-Token": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "return user info",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "educationSystem": {
-                                            "type": "string",
-                                            "description": "education system"
-                                        },
-                                        "department": {
-                                            "type": "string",
-                                            "description": "department"
-                                        },
-                                        "class": {
-                                            "type": "string",
-                                            "description": "class"
-                                        },
-                                        "id": {
-                                            "type": "string",
-                                            "description": "student id"
-                                        },
-                                        "nameCht": {
-                                            "type": "string",
-                                            "description": "student chinese name"
-                                        },
-                                        "nameEng": {
-                                            "type": "string",
-                                            "description": "student english name"
-                                        }
-                                    }
-                                },
-                                "example": {
-                                    "educationSystem": "日間部四技",
-                                    "department": "資訊工程系",
-                                    "class": "四資工四甲",
-                                    "id": "1104112345",
-                                    "nameCht": "葉大雄",
-                                    "nameEng": ""
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Token expired or Unauthorized Access"
-                    },
-                    "404": {
-                        "description": "Page not found"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    },
-                    "503": {
-                        "description": "Upstream server is timeout"
-                    },
-                    "504": {
-                        "description": "Upstream server is not alive"
-                    }
-                }
-            }
-        },
-        "/user/picture": {
-            "get": {
-                "tags": [
-                    "User"
-                ],
-                "summary": "get user's picture",
-                "security": [
-                    {
-                        "JSON-Web-Token": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "return picture url",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "url": {
-                                            "type": "string",
-                                            "description": "picUrl"
-                                        }
-                                    }
-                                },
-                                "example": {
-                                    "url": "http://webap.nkust.edu.tw/nkust/"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Token expired or Unauthorized Access"
-                    },
-                    "404": {
-                        "description": "Page not found"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    },
-                    "503": {
-                        "description": "Upstream server is timeout"
-                    },
-                    "504": {
-                        "description": "Upstream server is not alive"
-                    }
-                }
-            }
-        },
-        "/user/semester": {
-            "get": {
-                "tags": [
-                    "User"
-                ],
-                "summary": "get user's semester list",
-                "security": [
-                    {
-                        "JSON-Web-Token": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "return semester list",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "semester": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "value": {
-                                                        "type": "string",
-                                                        "description": "semester"
-                                                    },
-                                                    "text": {
-                                                        "type": "string",
-                                                        "description": "text"
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "default": {
-                                            "type": "object",
-                                            "properties": {
-                                                "value": {
-                                                    "type": "string",
-                                                    "description": "semester"
-                                                },
-                                                "text": {
-                                                    "type": "string",
-                                                    "description": "text"
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "example": {
-                                    "semester": [
-                                        {
-                                            "value": "107,1",
-                                            "text": "107學年度第1學期"
-                                        },
-                                        {
-                                            "value": "107,2",
-                                            "text": "107學年度第2學期"
-                                        }
-                                    ],
-                                    "default": {
-                                        "value": "107,2",
-                                        "text": "107學年度第2學期"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request"
-                    },
-                    "401": {
-                        "description": "Token expired or Unauthorized Access"
-                    },
-                    "404": {
-                        "description": "Page not found"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    },
-                    "503": {
-                        "description": "Upstream server is timeout"
-                    },
-                    "504": {
-                        "description": "Upstream server is not alive"
-                    }
-                }
-            }
-        },
-        "/user/scores": {
-            "get": {
-                "tags": [
-                    "User"
-                ],
-                "summary": "get user's scores",
-                "description": "If query parameters are empty then return the latest score.",
-                "security": [
-                    {
-                        "JSON-Web-Token": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "in": "query",
-                        "name": "year",
-                        "description": "year of semeter",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "in": "query",
-                        "name": "semester",
-                        "description": "number of semester",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "return score by year and semester",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "scores": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "title": {
-                                                        "type": "string",
-                                                        "description": "title"
-                                                    },
-                                                    "units": {
-                                                        "type": "string",
-                                                        "description": "course credit"
-                                                    },
-                                                    "hours": {
-                                                        "type": "string",
-                                                        "description": "course hour per week"
-                                                    },
-                                                    "required": {
-                                                        "type": "string",
-                                                        "description": "text"
-                                                    },
-                                                    "at": {
-                                                        "type": "string",
-                                                        "description": "text"
-                                                    },
-                                                    "middleScore": {
-                                                        "type": "string",
-                                                        "description": "midterm grade"
-                                                    },
-                                                    "finalScore": {
-                                                        "type": "string",
-                                                        "description": "final grade"
-                                                    },
-                                                    "remark": {
-                                                        "type": "string",
-                                                        "description": "text"
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "detail": {
-                                            "type": "object",
-                                            "properties": {
-                                                "conduct": {
-                                                    "type": "integer",
-                                                    "description": "conduct scores"
-                                                },
-                                                "average": {
-                                                    "type": "integer",
-                                                    "description": "average scores"
-                                                },
-                                                "classRank": {
-                                                    "type": "string",
-                                                    "description": "rank in class"
-                                                },
-                                                "classPercentage": {
-                                                    "type": "string",
-                                                    "description": "percentage in class"
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "example": {
-                                    "scores": {
-                                        "scores": [
-                                            {
-                                                "title": "專業倫理",
-                                                "units": "1.0",
-                                                "hours": "1.0",
-                                                "required": "【必修】",
-                                                "at": "【學期】",
-                                                "middleScore": "*",
-                                                "finalScore": "96.00",
-                                                "remark": ""
-                                            },
-                                            {
-                                                "title": "核心通識(三)-現今科技議題",
-                                                "units": "2.0",
-                                                "hours": "2.0",
-                                                "required": "【必修】",
-                                                "at": "【學期】",
-                                                "middleScore": "*",
-                                                "finalScore": "69.00",
-                                                "remark": ""
-                                            }
-                                        ],
-                                        "detail": {
-                                            "conduct": 82,
-                                            "average": 39,
-                                            "classRank": "57/57",
-                                            "classPercentage": 100
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request"
-                    },
-                    "401": {
-                        "description": "Token expired or Unauthorized Access"
-                    },
-                    "404": {
-                        "description": "Page not found"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    },
-                    "503": {
-                        "description": "Upstream server is timeout"
-                    },
-                    "504": {
-                        "description": "Upstream server is not alive"
-                    }
-                }
-            }
-        },
-        "/user/coursetables": {
-            "get": {
-                "tags": [
-                    "User"
-                ],
-                "summary": "get user's coursetables",
-                "description": "If query parameters are empty then return the latest coursetable.",
-                "security": [
-                    {
-                        "JSON-Web-Token": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "in": "query",
-                        "name": "year",
-                        "description": "year of semeter",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "in": "query",
-                        "name": "semester",
-                        "description": "number of semester",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "return coursetable by year and semester",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object"
-                                },
-                                "example": {
-                                    "coursetables": {
-                                        "Thursday": [
-                                            {
-                                                "title": "區塊鏈技術與應用",
-                                                "date": {
-                                                    "startTime": "09:10",
-                                                    "endTime": "10:00",
-                                                    "weekday": "R",
-                                                    "section": "第2節"
-                                                },
-                                                "location": {
-                                                    "building": "",
-                                                    "room": "育302"
-                                                },
-                                                "instructors": [
-                                                    "蕭淳元"
-                                                ]
-                                            },
-                                            {
-                                                "title": "區塊鏈技術與應用",
-                                                "date": {
-                                                    "startTime": "10:10",
-                                                    "endTime": "11:00",
-                                                    "weekday": "R",
-                                                    "section": "第3節"
-                                                },
-                                                "location": {
-                                                    "building": "",
-                                                    "room": "育302"
-                                                },
-                                                "instructors": [
-                                                    "蕭淳元"
-                                                ]
-                                            },
-                                            {
-                                                "title": "區塊鏈技術與應用",
-                                                "date": {
-                                                    "startTime": "11:10",
-                                                    "endTime": "12:00",
-                                                    "weekday": "R",
-                                                    "section": "第4節"
-                                                },
-                                                "location": {
-                                                    "building": "",
-                                                    "room": "育302"
-                                                },
-                                                "instructors": [
-                                                    "蕭淳元"
-                                                ]
-                                            },
-                                            {
-                                                "title": "圖形理論",
-                                                "date": {
-                                                    "startTime": "13:30",
-                                                    "endTime": "14:20",
-                                                    "weekday": "R",
-                                                    "section": "第5節"
-                                                },
-                                                "location": {
-                                                    "building": "",
-                                                    "room": "育305"
-                                                },
-                                                "instructors": [
-                                                    "鐘文鈺"
-                                                ]
-                                            },
-                                            {
-                                                "title": "圖形理論",
-                                                "date": {
-                                                    "startTime": "14:30",
-                                                    "endTime": "15:20",
-                                                    "weekday": "R",
-                                                    "section": "第6節"
-                                                },
-                                                "location": {
-                                                    "building": "",
-                                                    "room": "育305"
-                                                },
-                                                "instructors": [
-                                                    "鐘文鈺"
-                                                ]
-                                            },
-                                            {
-                                                "title": "圖形理論",
-                                                "date": {
-                                                    "startTime": "15:30",
-                                                    "endTime": "16:20",
-                                                    "weekday": "R",
-                                                    "section": "第7節"
-                                                },
-                                                "location": {
-                                                    "building": "",
-                                                    "room": "育305"
-                                                },
-                                                "instructors": [
-                                                    "鐘文鈺"
-                                                ]
-                                            }
-                                        ],
-                                        "Tuesday": [
-                                            {
-                                                "title": "高等資料庫",
-                                                "date": {
-                                                    "startTime": "13:30",
-                                                    "endTime": "14:20",
-                                                    "weekday": "T",
-                                                    "section": "第5節"
-                                                },
-                                                "location": {
-                                                    "building": "",
-                                                    "room": "育302"
-                                                },
-                                                "instructors": [
-                                                    "楊孟翰"
-                                                ]
-                                            },
-                                            {
-                                                "title": "高等資料庫",
-                                                "date": {
-                                                    "startTime": "14:30",
-                                                    "endTime": "15:20",
-                                                    "weekday": "T",
-                                                    "section": "第6節"
-                                                },
-                                                "location": {
-                                                    "building": "",
-                                                    "room": "育302"
-                                                },
-                                                "instructors": [
-                                                    "楊孟翰"
-                                                ]
-                                            },
-                                            {
-                                                "title": "高等資料庫",
-                                                "date": {
-                                                    "startTime": "15:30",
-                                                    "endTime": "16:20",
-                                                    "weekday": "T",
-                                                    "section": "第7節"
-                                                },
-                                                "location": {
-                                                    "building": "",
-                                                    "room": "育302"
-                                                },
-                                                "instructors": [
-                                                    "楊孟翰"
-                                                ]
-                                            }
-                                        ],
-                                        "timecode": [
-                                            "第M節",
-                                            "第1節",
-                                            "第2節",
-                                            "第3節",
-                                            "第4節",
-                                            "第A節",
-                                            "第5節",
-                                            "第6節",
-                                            "第7節",
-                                            "第8節",
-                                            "第9節",
-                                            "第10節",
-                                            "第11節",
-                                            "第12節",
-                                            "第13節"
-                                        ]
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request"
-                    },
-                    "401": {
-                        "description": "Token expired or Unauthorized Access"
-                    },
-                    "404": {
-                        "description": "Page not found"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    },
-                    "503": {
-                        "description": "Upstream server is timeout"
-                    },
-                    "504": {
-                        "description": "Upstream server is not alive"
-                    }
-                }
-            }
-        },
-        "/bus/timetables": {
-            "get": {
-                "tags": [
-                    "Bus"
-                ],
-                "summary": "get bus timetables",
-                "description": "If query parameters are empty then return the latest timetables.",
-                "security": [
-                    {
-                        "JSON-Web-Token": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "in": "query",
-                        "name": "date",
-                        "description": "date of timetables",
-                        "schema": {
-                            "type": "string",
-                            "format": "yyyy-MM-dd",
-                            "example": "2018-12-23"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "return bus timetables by date",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "timetable": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "endEnrollTime": {
-                                                        "type": "string",
-                                                        "description": "end enroll date time"
-                                                    },
-                                                    "departureTime": {
-                                                        "type": "string",
-                                                        "description": "course credit"
-                                                    },
-                                                    "endStation": {
-                                                        "type": "string",
-                                                        "description": "end station"
-                                                    },
-                                                    "busId": {
-                                                        "type": "string",
-                                                        "description": "bus id"
-                                                    },
-                                                    "discription": {
-                                                        "type": "string",
-                                                        "description": "text"
-                                                    },
-                                                    "cancelKey": {
-                                                        "type": "string",
-                                                        "description": "final grade"
-                                                    },
-                                                    "reserveCount": {
-                                                        "type": "integer",
-                                                        "description": "reserve count"
-                                                    },
-                                                    "limitCount": {
-                                                        "type": "integer",
-                                                        "description": "limit count"
-                                                    },
-                                                    "isReserve": {
-                                                        "type": "boolean",
-                                                        "description": "is reserve or not"
-                                                    },
-                                                    "specialTrain": {
-                                                        "type": "string",
-                                                        "description": "special train"
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "date": {
-                                            "type": "object",
-                                            "properties": {
-                                                "date": {
-                                                    "type": "string",
-                                                    "description": "ISO 8601 time"
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "example": {
-                                    "date": "2019-03-17T16:51:57Z",
-                                    "timetable": [
-                                        {
-                                            "endEnrollDateTime": "2019-03-17T16:51:57Z",
-                                            "departureTime": "2019-03-17T16:51:57Z",
-                                            "endStation": "燕巢",
-                                            "busId": "42705",
-                                            "reserveCount": 2,
-                                            "limitCount": 999,
-                                            "isReserve": true,
-                                            "specialTrain": "0",
-                                            "discription": "",
-                                            "cancelKey": 0
-                                        },
-                                        {
-                                            "endEnrollDateTime": "2019-03-17T16:51:57Z",
-                                            "departureTime": "2019-03-17T16:51:57Z",
-                                            "endStation": "燕巢",
-                                            "busId": "42711",
-                                            "reserveCount": 11,
-                                            "limitCount": 999,
-                                            "isReserve": false,
-                                            "SpecialTrain": "0",
-                                            "discription": "",
-                                            "cancelKey": 0
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request"
-                    },
-                    "401": {
-                        "description": "Token expired or Unauthorized Access"
-                    },
-                    "404": {
-                        "description": "Page not found"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    },
-                    "503": {
-                        "description": "Upstream server is timeout"
-                    },
-                    "504": {
-                        "description": "Upstream server is not alive"
-                    }
-                }
-            }
-        },
-        "/bus/reservations": {
-            "get": {
-                "tags": [
-                    "Bus"
-                ],
-                "summary": "get reservations",
-                "description": "If query parameters are empty then return the latest reservations.",
-                "security": [
-                    {
-                        "JSON-Web-Token": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "in": "query",
-                        "name": "busId",
-                        "description": "bus id",
-                        "schema": {
-                            "type": "string",
-                            "format": "yyyy-MM-dd",
-                            "example": "2018-12-23"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "return reservations by year and semester",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "reservation": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "time": {
-                                                        "type": "string",
-                                                        "description": "start time"
-                                                    },
-                                                    "endTime": {
-                                                        "type": "string",
-                                                        "description": "end time"
-                                                    },
-                                                    "cancelKey": {
-                                                        "type": "string",
-                                                        "description": "cancel key for cancel reserved bus"
-                                                    },
-                                                    "end": {
-                                                        "type": "string",
-                                                        "description": "end station"
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "example": {
-                                    "reservation": [
-                                        {
-                                            "time": "2019-03-17T16:51:57Z",
-                                            "endTime": "2019-03-14T08:20Z",
-                                            "cancelKey": "2004434",
-                                            "end": "燕巢"
-                                        },
-                                        {
-                                            "time": "2019-03-18T00:20Z",
-                                            "endTime": "2019-03-17T09:20Z",
-                                            "cancelKey": "2006005",
-                                            "end": "燕巢"
-                                        },
-                                        {
-                                            "time": "2019-03-18T08:40Z",
-                                            "endTime": "2019-03-18T03:40Z",
-                                            "cancelKey": "2006006",
-                                            "end": "建工"
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request"
-                    },
-                    "401": {
-                        "description": "Token expired or Unauthorized Access"
-                    },
-                    "404": {
-                        "description": "Page not found"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    },
-                    "503": {
-                        "description": "Upstream server is timeout"
-                    },
-                    "504": {
-                        "description": "Upstream server is not alive"
-                    }
-                }
-            },
-            "put": {
-                "tags": [
-                    "Bus"
-                ],
-                "summary": "reserve bus",
-                "description": "reserve bus",
-                "security": [
-                    {
-                        "JSON-Web-Token": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "in": "query",
-                        "name": "busId",
-                        "description": "bus id",
-                        "schema": {
-                            "type": "string",
-                            "example": "12345"
-                        },
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "return reservations by year and semester"
-                    },
-                    "400": {
-                        "description": "Bad Request"
-                    },
-                    "401": {
-                        "description": "Token expired or Unauthorized Access"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    },
-                    "503": {
-                        "description": "Upstream server is timeout"
-                    },
-                    "504": {
-                        "description": "Upstream server is not alive"
-                    }
-                }
-            },
-            "delete": {
-                "tags": [
-                    "Bus"
-                ],
-                "summary": "cancel reserved bus",
-                "description": "cancel reserved bus",
-                "security": [
-                    {
-                        "JSON-Web-Token": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "in": "query",
-                        "name": "cancelKey",
-                        "description": "cancel key",
-                        "schema": {
-                            "type": "string",
-                            "example": "3241"
-                        },
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "return reservations by year and semester"
-                    },
-                    "400": {
-                        "description": "Bad Request"
-                    },
-                    "401": {
-                        "description": "Token expired or Unauthorized Access"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    },
-                    "503": {
-                        "description": "Upstream server is timeout"
-                    },
-                    "504": {
-                        "description": "Upstream server is not alive"
-                    }
-                }
-            }
-        },
-        "/leaves": {
-            "get": {
-                "tags": [
-                    "Leave"
-                ],
-                "summary": "get user's absentees and leaves",
-                "description": "If query parameters are empty then return the latest absentees and leaves.",
-                "security": [
-                    {
-                        "JSON-Web-Token": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "in": "query",
-                        "name": "year",
-                        "description": "year of semeter",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "in": "query",
-                        "name": "semester",
-                        "description": "number of semester",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "return score by year and semester",
-                        "content": {
-                            "application/json": {
-                                "example": {
-                                    "leaves": [
-                                        {
-                                            "leaveSheetId": "",
-                                            "date": "107/11/14",
-                                            "instructors_comment": "",
-                                            "leave_sections": [
-                                                {
-                                                    "section": "5",
-                                                    "reason": "曠"
-                                                },
-                                                {
-                                                    "section": "6",
-                                                    "reason": "曠"
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "timecode": [
-                                        "A",
-                                        "1",
-                                        "2",
-                                        "3",
-                                        "4",
-                                        "B",
-                                        "5",
-                                        "6",
-                                        "7",
-                                        "8",
-                                        "C",
-                                        "11",
-                                        "12",
-                                        "13",
-                                        "14"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request"
-                    },
-                    "401": {
-                        "description": "Token expired or Unauthorized Access"
-                    },
-                    "404": {
-                        "description": "Page not found"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    },
-                    "503": {
-                        "description": "Upstream server is timeout"
-                    },
-                    "504": {
-                        "description": "Upstream server is not alive"
-                    }
-                }
-            }
-        }
+    "license": {
+      "name": "MIT License",
+      "url": "https://github.com/NKUST-ITC/AP-API/blob/master/LICENSE.md"
     },
-    "components": {
-        "schemas": {
-            "ServerInfo": {
-                "type": "object",
-                "properties": {
-                    "serverIime": {
-                        "type": "string",
-                        "description": "ISO 8601"
-                    },
-                    "services": {
-                        "$ref": "#/components/schemas/Service"
-                    }
-                },
-                "description": "all services status",
-                "example": {
-                    "date": "2019-03-16T20:16:04+08:00",
-                    "services": [
-                        {
-                            "service": "ap",
-                            "isAlive": true,
-                            "description": "校務系統"
-                        },
-                        {
-                            "service": "bus",
-                            "isAlive": true,
-                            "description": "校車系統"
-                        },
-                        {
-                            "service": "leave",
-                            "isAlive": true,
-                            "description": "缺曠系統"
-                        },
-                        {
-                            "service": "library",
-                            "isAlive": true,
-                            "description": "圖書館系統"
-                        }
-                    ]
-                }
-            },
-            "Service": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "service": {
-                            "type": "string"
-                        },
-                        "isAlive": {
-                            "type": "boolean"
-                        },
-                        "description": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "description": "all services status",
-                "example": [
-                    {
-                        "service": "ap",
-                        "isAlive": true,
-                        "description": "校務系統"
-                    },
-                    {
-                        "service": "bus",
-                        "isAlive": true,
-                        "description": "校車系統"
-                    },
-                    {
-                        "service": "leave",
-                        "isAlive": true,
-                        "description": "缺曠系統"
-                    },
-                    {
-                        "service": "library",
-                        "isAlive": true,
-                        "description": "圖書館系統"
-                    }
-                ]
-            },
-            "News": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "description": "id"
-                    },
-                    "nextid": {
-                        "type": "integer",
-                        "description": "next news id"
-                    },
-                    "lastId": {
-                        "type": "integer",
-                        "description": "next news id"
-                    },
-                    "title": {
-                        "type": "string",
-                        "description": "title"
-                    },
-                    "publishedAt": {
-                        "type": "string",
-                        "description": "publish time"
-                    },
-                    "url": {
-                        "type": "string",
-                        "description": "news url"
-                    },
-                    "imgUrl": {
-                        "type": "string",
-                        "description": "image url"
-                    },
-                    "description": {
-                        "type": "string",
-                        "description": "news description"
-                    }
-                },
-                "example": {
-                    "title": "高科校務通IOS版 回歸",
-                    "id": 1,
-                    "nextid": 2,
-                    "lastId": 5,
-                    "publishedAt": "2019-03-16T20:16:04+08:00",
-                    "imgUrl": "https://i.imgur.com/faSwvRv.jpg",
-                    "url": "https://nkustap.page.link/bCK1",
-                    "description": "重新推出 IOS 版本 高科校務通 此版本還在測試中 歡迎同學私訊粉專意見回饋\t"
-                }
-            },
-            "User": {
-                "type": "object",
-                "properties": {
-                    "username": {
-                        "type": "string"
-                    },
-                    "password": {
-                        "type": "string"
-                    }
-                },
-                "example": {
-                    "username": "110412345",
-                    "password": "1234"
-                }
-            },
-            "Auth": {
-                "type": "object",
-                "properties": {
-                    "expire_time": {
-                        "type": "string",
-                        "description": "ISO 8601"
-                    },
-                    "token": {
-                        "type": "string",
-                        "description": "JWT token"
-                    }
-                },
-                "example": {
-                    "expireTime": "2019-03-16T20:16:04+08:00",
-                    "token": "I6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtIjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJ",
-                    "services": [
-                        {
-                            "service": "ap",
-                            "isAlive": true,
-                            "description": "校務系統"
-                        },
-                        {
-                            "service": "bus",
-                            "isAlive": true,
-                            "description": "校車系統"
-                        },
-                        {
-                            "service": "leave",
-                            "isAlive": true,
-                            "description": "缺曠系統"
-                        },
-                        {
-                            "service": "library",
-                            "isAlive": true,
-                            "description": "圖書館系統"
-                        }
-                    ]
-                }
-            }
-        },
-        "securitySchemes": {
-            "BasicAuth": {
-                "type": "http",
-                "scheme": "basic"
-            },
-            "JSON-Web-Token": {
-                "type": "apiKey",
-                "in": "header",
-                "name": "Authorization"
-            }
-        }
+    "version": "3.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://nkust-ap-api.rainvisitor.me:2087/latest"
     }
+  ],
+  "tags": [
+    {
+      "name": "Authentication",
+      "description": "About authentication"
+    },
+    {
+      "name": "Server",
+      "description": "Some server info"
+    },
+    {
+      "name": "User",
+      "description": "Everything about user"
+    },
+    {
+      "name": "Bus",
+      "description": "Everything about bus"
+    },
+    {
+      "name": "News",
+      "description": "Everything about news"
+    },
+    {
+      "name": "Leave",
+      "description": "Everything about leave"
+    },
+    {
+      "name": "Library",
+      "description": "Everything about library"
+    }
+  ],
+  "paths": {
+    "/oauth/token": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "get a new token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "login sucess",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Auth"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Username or password is incorrect"
+          }
+        }
+      }
+    },
+    "/server/info": {
+      "get": {
+        "tags": [
+          "Server"
+        ],
+        "summary": "get server status (update every 10 minutes)",
+        "responses": {
+          "200": {
+            "description": "return server status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServerInfo"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Upstream server is timeout"
+          },
+          "504": {
+            "description": "Upstream server is not alive"
+          }
+        }
+      }
+    },
+    "/news/announcements": {
+      "get": {
+        "tags": [
+          "News"
+        ],
+        "summary": "get first announcements",
+        "responses": {
+          "200": {
+            "description": "return first news",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/News"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Page not found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/news/announcements/{id}": {
+      "get": {
+        "tags": [
+          "News"
+        ],
+        "summary": "get announcement by id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "description": "id or news",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "return news by id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/News"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Page not found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/news/announcements/all": {
+      "get": {
+        "tags": [
+          "News"
+        ],
+        "summary": "get all announcements",
+        "responses": {
+          "200": {
+            "description": "return all news",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "description": "id"
+                          },
+                          "nextid": {
+                            "type": "integer",
+                            "description": "next news id"
+                          },
+                          "lastId": {
+                            "type": "integer"
+                          },
+                          "title": {
+                            "type": "string",
+                            "description": "title"
+                          },
+                          "publishedTime": {
+                            "type": "string",
+                            "description": "publish time"
+                          },
+                          "url": {
+                            "type": "string",
+                            "description": "news url"
+                          },
+                          "imgUrl": {
+                            "type": "string",
+                            "description": "image url"
+                          },
+                          "description": {
+                            "type": "string",
+                            "description": "news description"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "data": [
+                    {
+                      "title": "高科校務通IOS版 回歸",
+                      "id": 1,
+                      "nextId": 2,
+                      "lastId": 2,
+                      "imgUrl": "https://i.imgur.com/faSwvRv.jpg",
+                      "url": "https://nkustap.page.link/bCK1",
+                      "description": "重新推出 IOS 版本 高科校務通 此版本還在測試中 歡迎同學私訊粉專意見回饋\t",
+                      "publishedTime": "2019-03-16T20:16:04+08:00"
+                    },
+                    {
+                      "title": "宿舍直達高鐵站專車",
+                      "id": 2,
+                      "nextId": -1,
+                      "lastId": 2,
+                      "imgUrl": "https://i.imgur.com/wwxD4Xa.png",
+                      "url": "",
+                      "description": "從燕巢宿舍直接發車，不用再走到公車站排隊 人數達25人即發車，一人只要30元喔",
+                      "publishedTime": "2019-03-16T20:16:04+08:00"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Page not found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/news/school": {
+      "get": {
+        "tags": [
+          "News"
+        ],
+        "summary": "get news",
+        "responses": {
+          "200": {
+            "description": "return school news",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "page": {
+                          "type": "integer"
+                        },
+                        "notification": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "link": {
+                                "type": "string"
+                              },
+                              "info": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "title": {
+                                    "type": "string"
+                                  },
+                                  "department": {
+                                    "type": "string"
+                                  },
+                                  "date": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "data": {
+                    "page": 1,
+                    "notification": [
+                      {
+                        "link": "http://kuasnews.kuas.edu.tw/files/13-1018-70766-1.php",
+                        "info": {
+                          "id": "1",
+                          "title": "2019年高科大高雄亮點日語導覽競賽",
+                          "department": "觀光系",
+                          "date": "2019-03-13"
+                        }
+                      },
+                      {
+                        "link": "http://gec.kuas.edu.tw/files/13-1012-70765-1.php",
+                        "info": {
+                          "id": "2",
+                          "title": "快來拿獎金!!!第22屆優質通識課程學生學習檔案e化徵選活動~",
+                          "department": "通識中心",
+                          "date": "2019-03-13"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Page not found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/user/info": {
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "summary": "get user's info",
+        "security": [
+          {
+            "JSON-Web-Token": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "return user info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "educationSystem": {
+                      "type": "string",
+                      "description": "education system"
+                    },
+                    "department": {
+                      "type": "string",
+                      "description": "department"
+                    },
+                    "className": {
+                      "type": "string",
+                      "description": "class"
+                    },
+                    "id": {
+                      "type": "string",
+                      "description": "student id"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "student name"
+                    },
+                    "pictureUrl": {
+                      "type": "string",
+                      "description": "student picture url"
+                    }
+                  }
+                },
+                "example": {
+                  "educationSystem": "日間部四技",
+                  "department": "資訊工程系",
+                  "className": "四資工四甲",
+                  "id": "1104112345",
+                  "name": "葉大雄",
+                  "pictureUrl": "http://webap.nkust.edu.tw/nkust/stdpics/XXXXX.jpg"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token expired or Unauthorized Access"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "description": "Upstream server is timeout"
+          }
+        }
+      }
+    },
+    "/user/semesters": {
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "summary": "get user's semester list",
+        "security": [
+          {
+            "JSON-Web-Token": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "return semester list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "year": {
+                            "type": "string",
+                            "description": "semester year"
+                          },
+                          "value": {
+                            "type": "string",
+                            "description": "semester"
+                          },
+                          "text": {
+                            "type": "string",
+                            "description": "text"
+                          }
+                        }
+                      }
+                    },
+                    "default": {
+                      "type": "object",
+                      "properties": {
+                        "year": {
+                          "type": "string",
+                          "description": "semester year"
+                        },
+                        "value": {
+                          "type": "string",
+                          "description": "semester"
+                        },
+                        "text": {
+                          "type": "string",
+                          "description": "text"
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "data": [
+                    {
+                      "year": "107",
+                      "value": "1",
+                      "text": "107學年度第1學期"
+                    },
+                    {
+                      "year": "107",
+                      "value": "2",
+                      "text": "107學年度第2學期"
+                    }
+                  ],
+                  "default": {
+                    "year": "107",
+                    "value": "2",
+                    "text": "107學年度第2學期"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token expired or Unauthorized Access"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "description": "Upstream server is timeout"
+          }
+        }
+      }
+    },
+    "/user/midterm-alerts": {
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "summary": "get user's midterm alerts",
+        "description": "Retrun this semester midterm alerts list",
+        "security": [
+          {
+            "JSON-Web-Token": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "year",
+            "description": "year of semeter",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "in": "query",
+            "name": "semester",
+            "description": "number of semester",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "return midterm alerts by year and semester",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "courses": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "enrty": {
+                            "type": "string",
+                            "description": "order"
+                          },
+                          "className": {
+                            "type": "string",
+                            "description": "class name"
+                          },
+                          "title": {
+                            "type": "string",
+                            "description": "title"
+                          },
+                          "group": {
+                            "type": "string",
+                            "description": "group"
+                          },
+                          "instructors": {
+                            "type": "string",
+                            "description": "course teacher"
+                          },
+                          "reason": {
+                            "type": "string",
+                            "description": "reason"
+                          },
+                          "remark": {
+                            "type": "string",
+                            "description": "text"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "courses": [
+                    {
+                      "entry": "01",
+                      "className": "四資工甲",
+                      "title": "專業倫理",
+                      "group": "01",
+                      "instructors": "陳洳瑾",
+                      "reason": "不認真",
+                      "remark": "還是不認真"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Token expired or Unauthorized Access"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "description": "Upstream server is timeout"
+          }
+        }
+      }
+    },
+    "/user/scores": {
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "summary": "get user's scores",
+        "description": "If query parameters are empty then return the latest score.",
+        "security": [
+          {
+            "JSON-Web-Token": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "year",
+            "description": "year of semeter",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "in": "query",
+            "name": "semester",
+            "description": "number of semester",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "return score by year and semester",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "scores": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "description": "title"
+                          },
+                          "units": {
+                            "type": "string",
+                            "description": "course credit"
+                          },
+                          "hours": {
+                            "type": "string",
+                            "description": "course hour per week"
+                          },
+                          "required": {
+                            "type": "string",
+                            "description": "text"
+                          },
+                          "at": {
+                            "type": "string",
+                            "description": "text"
+                          },
+                          "middleScore": {
+                            "type": "string",
+                            "description": "midterm grade"
+                          },
+                          "finalScore": {
+                            "type": "string",
+                            "description": "final grade"
+                          },
+                          "remark": {
+                            "type": "string",
+                            "description": "text"
+                          }
+                        }
+                      }
+                    },
+                    "detail": {
+                      "type": "object",
+                      "properties": {
+                        "conduct": {
+                          "type": "integer",
+                          "description": "conduct scores"
+                        },
+                        "average": {
+                          "type": "integer",
+                          "description": "average scores"
+                        },
+                        "classRank": {
+                          "type": "string",
+                          "description": "rank in class"
+                        },
+                        "classPercentage": {
+                          "type": "integer",
+                          "description": "percentage in class"
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "scores": [
+                    {
+                      "title": "專業倫理",
+                      "units": "1.0",
+                      "hours": "1.0",
+                      "required": "【必修】",
+                      "at": "【學期】",
+                      "middleScore": "*",
+                      "finalScore": "96.00",
+                      "remark": ""
+                    },
+                    {
+                      "title": "核心通識(三)-現今科技議題",
+                      "units": "2.0",
+                      "hours": "2.0",
+                      "required": "【必修】",
+                      "at": "【學期】",
+                      "middleScore": "*",
+                      "finalScore": "69.00",
+                      "remark": ""
+                    }
+                  ],
+                  "detail": {
+                    "conduct": 82,
+                    "average": 39,
+                    "classRank": "57/57",
+                    "classPercentage": 100
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Token expired or Unauthorized Access"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "description": "Upstream server is timeout"
+          }
+        }
+      }
+    },
+    "/user/coursetable": {
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "summary": "get user's coursetables",
+        "description": "If query parameters are empty then return the latest coursetable.",
+        "security": [
+          {
+            "JSON-Web-Token": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "year",
+            "description": "year of semeter",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "in": "query",
+            "name": "semester",
+            "description": "number of semester",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "return coursetable by year and semester",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "courses": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string",
+                            "description": "class code"
+                          },
+                          "title": {
+                            "type": "string",
+                            "description": "class title"
+                          },
+                          "className": {
+                            "type": "string",
+                            "description": "class name"
+                          },
+                          "group": {
+                            "type": "string",
+                            "description": "group number"
+                          },
+                          "units": {
+                            "type": "string",
+                            "description": "text"
+                          },
+                          "hours": {
+                            "type": "string",
+                            "description": "midterm grade"
+                          },
+                          "at": {
+                            "type": "string",
+                            "description": "final grade"
+                          },
+                          "times": {
+                            "type": "string",
+                            "description": "text"
+                          },
+                          "location": {
+                            "type": "object",
+                            "properties": {
+                              "building": {
+                                "type": "string",
+                                "description": "e.g. 滕雄館"
+                              },
+                              "room": {
+                                "type": "string",
+                                "description": "class room"
+                              }
+                            }
+                          },
+                          "instructors": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "description": "teacher name"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "coursetable": {
+                      "type": "object",
+                      "properties": {
+                        "Thursday": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "type": "string",
+                                "description": "class title"
+                              },
+                              "date": {
+                                "type": "object",
+                                "properties": {
+                                  "startTime": {
+                                    "type": "string"
+                                  },
+                                  "endTime": {
+                                    "type": "string"
+                                  },
+                                  "section": {
+                                    "type": "string",
+                                    "description": "節次"
+                                  }
+                                }
+                              },
+                              "location": {
+                                "type": "object",
+                                "properties": {
+                                  "building": {
+                                    "type": "string",
+                                    "description": "e.g. 滕雄館"
+                                  },
+                                  "room": {
+                                    "type": "string",
+                                    "description": "class room"
+                                  }
+                                }
+                              },
+                              "instructors": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "description": "teacher name"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "timeCodes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "description": "show in forntend"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "courses": [
+                    {
+                      "code": "0430",
+                      "title": "區塊鏈技術與應用",
+                      "className": "碩資工一甲",
+                      "group": "01",
+                      "units": "3.0",
+                      "hours": "3.0",
+                      "required": "【選修】",
+                      "at": "【學期】",
+                      "times": "(四)5-7",
+                      "location": {
+                        "room": "育305"
+                      },
+                      "instructors": [
+                        "鐘文鈺"
+                      ]
+                    },
+                    {
+                      "code": "0431",
+                      "title": "高等資料庫",
+                      "className": "碩資工一甲",
+                      "group": "01",
+                      "units": "3.0",
+                      "hours": "3.0",
+                      "required": "【選修】",
+                      "at": "【學期】",
+                      "times": "(二)5-7",
+                      "location": {
+                        "room": "育302"
+                      },
+                      "instructors": [
+                        "楊孟翰"
+                      ]
+                    },
+                    {
+                      "code": "0434",
+                      "title": "區塊鏈技術與應用",
+                      "className": "碩資工一甲",
+                      "group": "01",
+                      "units": "3.0",
+                      "hours": "3.0",
+                      "required": "【選修】",
+                      "at": "【學期】",
+                      "times": "(四)2-4",
+                      "location": {
+                        "room": "育302"
+                      },
+                      "instructors": [
+                        "楊孟翰"
+                      ]
+                    }
+                  ],
+                  "coursetable": {
+                    "Thursday": [
+                      {
+                        "title": "區塊鏈技術與應用",
+                        "date": {
+                          "startTime": "09:10",
+                          "endTime": "10:00",
+                          "section": "第2節"
+                        },
+                        "location": {
+                          "room": "育302"
+                        },
+                        "instructors": [
+                          "蕭淳元"
+                        ]
+                      },
+                      {
+                        "title": "區塊鏈技術與應用",
+                        "date": {
+                          "startTime": "10:10",
+                          "endTime": "11:00",
+                          "section": "第3節"
+                        },
+                        "location": {
+                          "room": "育302"
+                        },
+                        "instructors": [
+                          "蕭淳元"
+                        ]
+                      },
+                      {
+                        "title": "區塊鏈技術與應用",
+                        "date": {
+                          "startTime": "11:10",
+                          "endTime": "12:00",
+                          "section": "第4節"
+                        },
+                        "location": {
+                          "room": "育302"
+                        },
+                        "instructors": [
+                          "蕭淳元"
+                        ]
+                      },
+                      {
+                        "title": "圖形理論",
+                        "date": {
+                          "startTime": "13:30",
+                          "endTime": "14:20",
+                          "section": "第5節"
+                        },
+                        "location": {
+                          "room": "育305"
+                        },
+                        "instructors": [
+                          "鐘文鈺"
+                        ]
+                      },
+                      {
+                        "title": "圖形理論",
+                        "date": {
+                          "startTime": "14:30",
+                          "endTime": "15:20",
+                          "section": "第6節"
+                        },
+                        "location": {
+                          "room": "育305"
+                        },
+                        "instructors": [
+                          "鐘文鈺"
+                        ]
+                      },
+                      {
+                        "title": "圖形理論",
+                        "date": {
+                          "startTime": "15:30",
+                          "endTime": "16:20",
+                          "weekday": "R",
+                          "section": "第7節"
+                        },
+                        "location": {
+                          "room": "育305"
+                        },
+                        "instructors": [
+                          "鐘文鈺"
+                        ]
+                      }
+                    ],
+                    "Tuesday": [
+                      {
+                        "title": "高等資料庫",
+                        "date": {
+                          "startTime": "13:30",
+                          "endTime": "14:20",
+                          "section": "第5節"
+                        },
+                        "location": {
+                          "room": "育302"
+                        },
+                        "instructors": [
+                          "楊孟翰"
+                        ]
+                      },
+                      {
+                        "title": "高等資料庫",
+                        "date": {
+                          "startTime": "14:30",
+                          "endTime": "15:20",
+                          "section": "第6節"
+                        },
+                        "location": {
+                          "room": "育302"
+                        },
+                        "instructors": [
+                          "楊孟翰"
+                        ]
+                      },
+                      {
+                        "title": "高等資料庫",
+                        "date": {
+                          "startTime": "15:30",
+                          "endTime": "16:20",
+                          "section": "第7節"
+                        },
+                        "location": {
+                          "room": "育302"
+                        },
+                        "instructors": [
+                          "楊孟翰"
+                        ]
+                      }
+                    ],
+                    "timeCodes": [
+                      "第M節",
+                      "第1節",
+                      "第2節",
+                      "第3節",
+                      "第4節",
+                      "第A節",
+                      "第5節",
+                      "第6節",
+                      "第7節",
+                      "第8節",
+                      "第9節",
+                      "第10節",
+                      "第11節",
+                      "第12節",
+                      "第13節"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Token expired or Unauthorized Access"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "description": "Upstream server is timeout"
+          }
+        }
+      }
+    },
+    "/user/reward-and-penalty": {
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "summary": "get user's reward and punishments",
+        "description": "If query parameters are empty then return the latest reward and punishments.",
+        "security": [
+          {
+            "JSON-Web-Token": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "year",
+            "description": "year of semeter",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "in": "query",
+            "name": "semester",
+            "description": "number of semester",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "return reward and punishments by year and semester",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "date": {
+                            "type": "string",
+                            "description": "title"
+                          },
+                          "type": {
+                            "type": "integer",
+                            "description": "type"
+                          },
+                          "counts": {
+                            "type": "integer",
+                            "description": "number of reward and punishments"
+                          },
+                          "reason": {
+                            "type": "string",
+                            "description": "text"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "data": [
+                    {
+                      "date": "1040618",
+                      "type": "小功",
+                      "counts": 2,
+                      "reason": "擔任幹部認真負責(副班長)"
+                    },
+                    {
+                      "date": "1040624",
+                      "type": "嘉獎",
+                      "counts": 1,
+                      "reason": "擔任幹部認真負責"
+                    },
+                    {
+                      "date": "1040629",
+                      "type": "嘉獎",
+                      "counts": 1,
+                      "reason": "辦理系學會活動盡心盡力"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Token expired or Unauthorized Access"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "description": "Upstream server is timeout"
+          }
+        }
+      }
+    },
+    "/user/graduation-threshold": {
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "summary": "get user's graduation threshold state",
+        "security": [
+          {
+            "JSON-Web-Token": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "return user info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "description": "student basic data",
+                      "properties": {
+                        "studentName": {
+                          "type": "string",
+                          "description": "student name"
+                        },
+                        "className": {
+                          "type": "string",
+                          "description": "student's class name"
+                        },
+                        "id": {
+                          "type": "string",
+                          "description": "student id"
+                        }
+                      }
+                    },
+                    "englishPass": {
+                      "type": "string",
+                      "description": "school english graduation threshold pass state"
+                    },
+                    "englishClassPass": {
+                      "type": "string",
+                      "description": "english ability class pass state"
+                    },
+                    "internships": {
+                      "type": "array",
+                      "description": "internships class list",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "year": {
+                            "type": "string",
+                            "description": "class of year"
+                          },
+                          "semester": {
+                            "type": "string",
+                            "description": "class of semester"
+                          },
+                          "code": {
+                            "type": "string",
+                            "description": "class of code"
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "class of name"
+                          },
+                          "score": {
+                            "type": "integer",
+                            "description": "class of score"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "data": {
+                    "name": "葉大雄",
+                    "className": "四資工四甲",
+                    "id": "1103412345"
+                  },
+                  "englishPass": "通過",
+                  "englishClassPass": "及格通過"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token expired or Unauthorized Access"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "description": "Upstream server is timeout"
+          }
+        }
+      }
+    },
+    "/bus/timetables": {
+      "get": {
+        "tags": [
+          "Bus"
+        ],
+        "summary": "get bus timetables",
+        "description": "If query parameters are empty then return the latest timetables.",
+        "security": [
+          {
+            "JSON-Web-Token": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "date",
+            "description": "date of timetables",
+            "schema": {
+              "type": "string",
+              "format": "yyyy-MM-dd",
+              "example": "2018-12-23"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "return bus timetables by date",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "timetable": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "endEnrollTime": {
+                            "type": "string",
+                            "description": "end enroll date time"
+                          },
+                          "departureTime": {
+                            "type": "string",
+                            "description": "course credit"
+                          },
+                          "startStation": {
+                            "type": "string",
+                            "description": "start station"
+                          },
+                          "busId": {
+                            "type": "string",
+                            "description": "bus id"
+                          },
+                          "discription": {
+                            "type": "string",
+                            "description": "text"
+                          },
+                          "cancelKey": {
+                            "type": "string",
+                            "description": "final grade"
+                          },
+                          "reserveCount": {
+                            "type": "integer",
+                            "description": "reserve count"
+                          },
+                          "limitCount": {
+                            "type": "integer",
+                            "description": "limit count"
+                          },
+                          "isReserve": {
+                            "type": "boolean",
+                            "description": "is reserve or not"
+                          },
+                          "specialTrain": {
+                            "type": "string",
+                            "description": "special train"
+                          },
+                          "homeCharteredBus": {
+                            "type": "boolean",
+                            "description": "is return home bus"
+                          }
+                        }
+                      }
+                    },
+                    "date": {
+                      "type": "object",
+                      "properties": {
+                        "date": {
+                          "type": "string",
+                          "description": "ISO 8601 time"
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "date": "2019-03-17T16:51:57Z",
+                  "data": [
+                    {
+                      "endEnrollDateTime": "2019-03-17T16:51:57Z",
+                      "departureTime": "2019-03-17T16:51:57Z",
+                      "startStation": "建工",
+                      "busId": "42705",
+                      "reserveCount": 2,
+                      "limitCount": 999,
+                      "isReserve": true,
+                      "specialTrain": "0",
+                      "discription": "",
+                      "cancelKey": 0,
+                      "homeCharteredBus": false
+                    },
+                    {
+                      "endEnrollDateTime": "2019-03-17T16:51:57Z",
+                      "departureTime": "2019-03-17T16:51:57Z",
+                      "startStation": "建工",
+                      "busId": "42711",
+                      "reserveCount": 11,
+                      "limitCount": 999,
+                      "isReserve": false,
+                      "SpecialTrain": "0",
+                      "discription": "",
+                      "cancelKey": 0,
+                      "homeCharteredBus": false
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Token expired or Unauthorized Access"
+          },
+          "404": {
+            "description": "Page not found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "description": "Upstream server is timeout"
+          },
+          "504": {
+            "description": "Upstream server is not alive"
+          }
+        }
+      }
+    },
+    "/bus/reservations": {
+      "get": {
+        "tags": [
+          "Bus"
+        ],
+        "summary": "get reservations",
+        "description": "If query parameters are empty then return the latest reservations.",
+        "security": [
+          {
+            "JSON-Web-Token": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "return reservations by year and semester",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "reservation": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "time": {
+                            "type": "string",
+                            "description": "start time"
+                          },
+                          "endTime": {
+                            "type": "string",
+                            "description": "end time"
+                          },
+                          "cancelKey": {
+                            "type": "string",
+                            "description": "cancel key for cancel reserved bus"
+                          },
+                          "start": {
+                            "type": "string",
+                            "description": "start station"
+                          },
+                          "state": {
+                            "type": "string",
+                            "description": "bus reserve state"
+                          },
+                          "travelState": {
+                            "type": "string",
+                            "description": "bus reserve travel state"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "data": [
+                    {
+                      "dateTime": "2019-03-17T16:51:57Z",
+                      "endTime": "2019-03-14T08:20Z",
+                      "cancelKey": "2004434",
+                      "start": "建工",
+                      "state": "0",
+                      "travelState": "0"
+                    },
+                    {
+                      "dateTime": "2019-03-18T00:20Z",
+                      "endTime": "2019-03-17T09:20Z",
+                      "cancelKey": "2006005",
+                      "start": "建工",
+                      "state": "0",
+                      "travelState": "0"
+                    },
+                    {
+                      "dateTime": "2019-03-18T08:40Z",
+                      "endTime": "2019-03-18T03:40Z",
+                      "cancelKey": "2006006",
+                      "start": "燕巢",
+                      "state": "0",
+                      "travelState": "0"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Token expired or Unauthorized Access"
+          },
+          "404": {
+            "description": "Page not found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "description": "Upstream server is timeout"
+          },
+          "504": {
+            "description": "Upstream server is not alive"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Bus"
+        ],
+        "summary": "reserve bus",
+        "description": "reserve bus",
+        "security": [
+          {
+            "JSON-Web-Token": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "busId",
+            "description": "bus id",
+            "schema": {
+              "type": "string",
+              "example": "12345"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "return reservations by year and semester"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Token expired or Unauthorized Access"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "description": "Upstream server is timeout"
+          },
+          "504": {
+            "description": "Upstream server is not alive"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Bus"
+        ],
+        "summary": "cancel reserved bus",
+        "description": "cancel reserved bus",
+        "security": [
+          {
+            "JSON-Web-Token": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "cancelKey",
+            "description": "cancel key",
+            "schema": {
+              "type": "string",
+              "example": "3241"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "return reservations by year and semester"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Token expired or Unauthorized Access"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "description": "Upstream server is timeout"
+          },
+          "504": {
+            "description": "Upstream server is not alive"
+          }
+        }
+      }
+    },
+    "/bus/violation-records": {
+      "get": {
+        "tags": [
+          "Bus"
+        ],
+        "summary": "get bus violation records",
+        "description": "",
+        "security": [
+          {
+            "JSON-Web-Token": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "return bus violation records",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "reservation": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "time": {
+                            "type": "string",
+                            "description": "start time"
+                          },
+                          "startStation": {
+                            "type": "string",
+                            "description": "start station"
+                          },
+                          "homeCharteredBus": {
+                            "type": "boolean",
+                            "description": "is return home bus"
+                          },
+                          "amountend": {
+                            "type": "string",
+                            "description": "amountend of violation"
+                          },
+                          "isPayment": {
+                            "type": "string",
+                            "description": "text"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "reservation": [
+                    {
+                      "time": "2019-03-17T16:51:57Z",
+                      "startStation": "建工",
+                      "homeCharteredBus": false,
+                      "amountend": 30,
+                      "isPayment": ""
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Token expired or Unauthorized Access"
+          },
+          "404": {
+            "description": "Page not found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "description": "Upstream server is timeout"
+          },
+          "504": {
+            "description": "Upstream server is not alive"
+          }
+        }
+      }
+    },
+    "/user/room/list": {
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "summary": "get campus room List",
+        "description": "",
+        "security": [
+          {
+            "JSON-Web-Token": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "campus",
+            "description": "1=建工  /2=燕巢/3=第一/4=楠梓/5=旗津",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "return roomName & roomId",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "roomName": {
+                            "type": "string",
+                            "description": "room name"
+                          },
+                          "roomId": {
+                            "type": "string",
+                            "description": "shorthand room name ."
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "data": [
+                    {
+                      "roomName": "(東棟)東001",
+                      "roomId": "A001"
+                    },
+                    {
+                      "roomName": "(司令台)司207",
+                      "roomId": "J207"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Token expired or Unauthorized Access"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "description": "Upstream server is timeout"
+          }
+        }
+      }
+    },
+    "/user/empty-room/info": {
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "summary": "get room's info",
+        "description": "",
+        "security": [
+          {
+            "JSON-Web-Token": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "roomId",
+            "description": "like A001...",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "in": "query",
+            "name": "year",
+            "description": "year of semeter",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "in": "query",
+            "name": "semester",
+            "description": "number of semester",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "return roomName & roomId",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "courses": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string",
+                            "description": "class code"
+                          },
+                          "title": {
+                            "type": "string",
+                            "description": "class title"
+                          },
+                          "className": {
+                            "type": "string",
+                            "description": "class name"
+                          },
+                          "group": {
+                            "type": "string",
+                            "description": "group number"
+                          },
+                          "units": {
+                            "type": "string",
+                            "description": "text"
+                          },
+                          "hours": {
+                            "type": "string",
+                            "description": "midterm grade"
+                          },
+                          "required": {
+                            "type": "string",
+                            "description": "必選修"
+                          },
+                          "at": {
+                            "type": "string",
+                            "description": "final grade"
+                          },
+                          "times": {
+                            "type": "string",
+                            "description": "text"
+                          },
+                          "instructors": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "description": "teacher name"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "coursetable": {
+                      "type": "object",
+                      "properties": {
+                        "Thursday": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "type": "string",
+                                "description": "class title"
+                              },
+                              "date": {
+                                "type": "object",
+                                "properties": {
+                                  "startTime": {
+                                    "type": "string"
+                                  },
+                                  "endTime": {
+                                    "type": "string"
+                                  },
+                                  "weekday": {
+                                    "type": "string"
+                                  },
+                                  "section": {
+                                    "type": "string",
+                                    "description": "節次"
+                                  }
+                                }
+                              },
+                              "instructors": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "description": "teacher name"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "timeCodes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "description": "show in forntend"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "example": {
+                    "courses": [
+                      {
+                        "code": "0430",
+                        "title": "區塊鏈技術與應用",
+                        "className": "碩資工一甲",
+                        "group": "01",
+                        "units": "3.0",
+                        "hours": "3.0",
+                        "required": "【選修】",
+                        "at": "【學期】",
+                        "times": "(四)5-7",
+                        "instructors": [
+                          "鐘文鈺"
+                        ]
+                      },
+                      {
+                        "code": "0431",
+                        "title": "高等資料庫",
+                        "className": "碩資工一甲",
+                        "group": "01",
+                        "units": "3.0",
+                        "hours": "3.0",
+                        "required": "【選修】",
+                        "at": "【學期】",
+                        "times": "(二)5-7",
+                        "instructors": [
+                          "楊孟翰"
+                        ]
+                      }
+                    ],
+                    "coursetable": {
+                      "Thursday": [
+                        {
+                          "title": "區塊鏈技術與應用",
+                          "date": {
+                            "startTime": "09:10",
+                            "endTime": "10:00",
+                            "weekday": "R",
+                            "section": "第2節"
+                          },
+                          "instructors": [
+                            "蕭淳元"
+                          ]
+                        },
+                        {
+                          "title": "區塊鏈技術與應用",
+                          "date": {
+                            "startTime": "10:10",
+                            "endTime": "11:00",
+                            "weekday": "R",
+                            "section": "第3節"
+                          },
+                          "instructors": [
+                            "蕭淳元"
+                          ]
+                        },
+                        {
+                          "title": "區塊鏈技術與應用",
+                          "date": {
+                            "startTime": "11:10",
+                            "endTime": "12:00",
+                            "weekday": "R",
+                            "section": "第4節"
+                          },
+                          "instructors": [
+                            "蕭淳元"
+                          ]
+                        }
+                      ],
+                      "Tuesday": [
+                        {
+                          "title": "高等資料庫",
+                          "date": {
+                            "startTime": "13:30",
+                            "endTime": "14:20",
+                            "weekday": "T",
+                            "section": "第5節"
+                          },
+                          "instructors": [
+                            "楊孟翰"
+                          ]
+                        },
+                        {
+                          "title": "高等資料庫",
+                          "date": {
+                            "startTime": "14:30",
+                            "endTime": "15:20",
+                            "weekday": "T",
+                            "section": "第6節"
+                          },
+                          "instructors": [
+                            "楊孟翰"
+                          ]
+                        },
+                        {
+                          "title": "高等資料庫",
+                          "date": {
+                            "startTime": "15:30",
+                            "endTime": "16:20",
+                            "weekday": "T",
+                            "section": "第7節"
+                          },
+                          "instructors": [
+                            "楊孟翰"
+                          ]
+                        }
+                      ],
+                      "timeCodes": [
+                        "第M節",
+                        "第1節",
+                        "第2節",
+                        "第3節",
+                        "第4節",
+                        "第A節",
+                        "第5節",
+                        "第6節",
+                        "第7節",
+                        "第8節",
+                        "第9節",
+                        "第10節",
+                        "第11節",
+                        "第12節",
+                        "第13節"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Token expired or Unauthorized Access"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "description": "Upstream server is timeout"
+          }
+        }
+      }
+    },
+    "/leaves": {
+      "get": {
+        "tags": [
+          "Leave"
+        ],
+        "summary": "get user's absentees and leaves",
+        "description": "If query parameters are empty then return the latest absentees and leaves.",
+        "security": [
+          {
+            "JSON-Web-Token": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "year",
+            "description": "year of semeter",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "in": "query",
+            "name": "semester",
+            "description": "number of semester",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "return score by year and semester",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "leaveSheetId": {
+                            "type": "string"
+                          },
+                          "date": {
+                            "type": "string",
+                            "description": "just date without time"
+                          },
+                          "instructorsComment": {
+                            "type": "string"
+                          },
+                          "sections": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "section": {
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "timeCodes": {
+                      "type": "array",
+                      "description": "timecode use fill user need leave submit sections",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "data": [
+                    {
+                      "leaveSheetId": "",
+                      "date": "107/11/14",
+                      "instructorsComment": "",
+                      "sections": [
+                        {
+                          "section": "5",
+                          "reason": "曠"
+                        },
+                        {
+                          "section": "6",
+                          "reason": "曠"
+                        }
+                      ]
+                    }
+                  ],
+                  "timeCodes": [
+                    "A",
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "B",
+                    "5",
+                    "6",
+                    "7",
+                    "8",
+                    "C",
+                    "11",
+                    "12",
+                    "13",
+                    "14"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Token expired or Unauthorized Access"
+          },
+          "404": {
+            "description": "Page not found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "description": "Upstream server is timeout"
+          },
+          "504": {
+            "description": "Upstream server is not alive"
+          }
+        }
+      }
+    },
+    "/leaves/submit": {
+      "post": {
+        "tags": [
+          "Leave"
+        ],
+        "summary": "post leave form",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/leaveSubmit"
+              }
+            }
+          }
+        },
+        "description": "If query parameters are empty then return the latest absentees and leaves.",
+        "security": [
+          {
+            "JSON-Web-Token": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "done"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Token expired or Unauthorized Access"
+          },
+          "404": {
+            "description": "Page not found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "description": "Upstream server is timeout"
+          },
+          "504": {
+            "description": "Upstream server is not alive"
+          }
+        }
+      }
+    },
+    "/leaves/submit/info": {
+      "get": {
+        "tags": [
+          "Leave"
+        ],
+        "summary": "get user's absentees submit permission and required data",
+        "description": "",
+        "security": [
+          {
+            "JSON-Web-Token": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "return score by year and semester",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "tutors": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "teacher's name"
+                        }
+                      }
+                    },
+                    "type": {
+                      "type": "object",
+                      "description": "leaves type",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "need use id apply leave submit"
+                        },
+                        "title": {
+                          "type": "string",
+                          "description": "text"
+                        }
+                      }
+                    },
+                    "timeCodes": {
+                      "type": "array",
+                      "description": "timecode use fill user need leave submit sections",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "tutors": {
+                    "name": "柯博昌"
+                  },
+                  "type": [
+                    {
+                      "id": "21",
+                      "title": "事假"
+                    },
+                    {
+                      "id": "22",
+                      "title": "病假"
+                    },
+                    {
+                      "id": "23",
+                      "title": "公假"
+                    },
+                    {
+                      "id": "24",
+                      "title": "喪假"
+                    },
+                    {
+                      "id": "42",
+                      "title": "產假"
+                    }
+                  ],
+                  "teacherList": [
+                    {
+                      "teacherName": "柯博昌",
+                      "teacherId": "10023"
+                    },
+                    {
+                      "teacherName": "柯博昌",
+                      "teacherId": "100220"
+                    }
+                  ],
+                  "timeCodes": [
+                    "A",
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "B",
+                    "5",
+                    "6",
+                    "7",
+                    "8",
+                    "C",
+                    "11",
+                    "12",
+                    "13",
+                    "14"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Token expired or Unauthorized Access"
+          },
+          "403": {
+            "description": "User can't user this feature"
+          },
+          "404": {
+            "description": "Page not found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "description": "Upstream server is timeout"
+          },
+          "504": {
+            "description": "Upstream server is not alive"
+          }
+        }
+      }
+    },
+    "/library/info": {
+      "get": {
+        "tags": [
+          "Library"
+        ],
+        "summary": "get user's absentees and leaves",
+        "description": "library system client info ",
+        "security": [
+          {
+            "JSON-Web-Token": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "return score by year and semester",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "department": {
+                          "type": "string"
+                        },
+                        "libraryId": {
+                          "type": "string"
+                        },
+                        "studentName": {
+                          "type": "string"
+                        },
+                        "record": {
+                          "type": "object",
+                          "properties": {
+                            "borrowing": {
+                              "type": "integer",
+                              "description": "未過期 借閱中"
+                            },
+                            "reserve-rental": {
+                              "type": "integer",
+                              "description": "預約/調借紀錄"
+                            },
+                            "userFine": {
+                              "type": "integer",
+                              "description": "罰款"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "data": {
+                    "department": "智慧商務系QQ",
+                    "libraryId": "1106133333",
+                    "name": "柯博昌",
+                    "record": {
+                      "borrowing": 1,
+                      "reserve-rental": 2,
+                      "userFine": 300
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Token expired or Unauthorized Access"
+          },
+          "404": {
+            "description": "Page not found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "description": "Upstream server is timeout"
+          },
+          "504": {
+            "description": "Upstream server is not alive"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ServerInfo": {
+        "type": "object",
+        "properties": {
+          "date": {
+            "type": "string",
+            "description": "ISO 8601"
+          },
+          "data": {
+            "$ref": "#/components/schemas/Service"
+          }
+        },
+        "description": "all services status",
+        "example": {
+          "date": "2019-03-16T20:16:04+08:00",
+          "data": [
+            {
+              "service": "ap",
+              "isAlive": true,
+              "description": "校務系統"
+            },
+            {
+              "service": "bus",
+              "isAlive": true,
+              "description": "校車系統"
+            },
+            {
+              "service": "leave",
+              "isAlive": true,
+              "description": "缺曠系統"
+            },
+            {
+              "service": "library",
+              "isAlive": true,
+              "description": "圖書館系統"
+            }
+          ]
+        }
+      },
+      "Service": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "service": {
+              "type": "string"
+            },
+            "isAlive": {
+              "type": "boolean"
+            },
+            "description": {
+              "type": "string"
+            }
+          }
+        },
+        "description": "all services status",
+        "example": [
+          {
+            "service": "ap",
+            "isAlive": true,
+            "description": "校務系統"
+          },
+          {
+            "service": "bus",
+            "isAlive": true,
+            "description": "校車系統"
+          },
+          {
+            "service": "leave",
+            "isAlive": true,
+            "description": "缺曠系統"
+          },
+          {
+            "service": "library",
+            "isAlive": true,
+            "description": "圖書館系統"
+          }
+        ]
+      },
+      "News": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "id"
+          },
+          "nextid": {
+            "type": "integer",
+            "description": "next news id"
+          },
+          "lastId": {
+            "type": "integer",
+            "description": "next news id"
+          },
+          "title": {
+            "type": "string",
+            "description": "title"
+          },
+          "publishedAt": {
+            "type": "string",
+            "description": "publish time"
+          },
+          "url": {
+            "type": "string",
+            "description": "news url"
+          },
+          "imgUrl": {
+            "type": "string",
+            "description": "image url"
+          },
+          "description": {
+            "type": "string",
+            "description": "news description"
+          }
+        },
+        "example": {
+          "title": "高科校務通IOS版 回歸",
+          "id": 1,
+          "nextid": 2,
+          "lastId": 5,
+          "publishedAt": "2019-03-16T20:16:04+08:00",
+          "imgUrl": "https://i.imgur.com/faSwvRv.jpg",
+          "url": "https://nkustap.page.link/bCK1",
+          "description": "重新推出 IOS 版本 高科校務通 此版本還在測試中 歡迎同學私訊粉專意見回饋\t"
+        }
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          }
+        },
+        "example": {
+          "username": "110412345",
+          "password": "1234"
+        }
+      },
+      "Auth": {
+        "type": "object",
+        "properties": {
+          "expire_time": {
+            "type": "string",
+            "description": "ISO 8601"
+          },
+          "token": {
+            "type": "string",
+            "description": "JWT token"
+          }
+        },
+        "example": {
+          "expireTime": "2019-03-16T20:16:04+08:00",
+          "token": "I6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtIjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJ"
+        }
+      },
+      "leaveSubmit": {
+        "type": "object",
+        "properties": {
+          "days": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "day": {
+                  "type": "string"
+                },
+                "class": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "teacherId": {
+            "type": "string"
+          },
+          "leaveType": {
+            "type": "string"
+          },
+          "reasonText": {
+            "type": "string"
+          }
+        },
+        "example": {
+          "days": [
+            {
+              "day": "2019/03/03",
+              "class": [
+                "A",
+                "3",
+                "5"
+              ]
+            },
+            {
+              "day": "2019/03/05",
+              "class": [
+                "2",
+                "3"
+              ]
+            }
+          ],
+          "leaveType": "21",
+          "teacherId": "10041",
+          "reasonText": "我不當人類拉 JOJO!!!!!"
+        }
+      }
+    },
+    "securitySchemes": {
+      "JSON-Web-Token": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization"
+      }
+    }
+  }
 }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -49,7 +49,32 @@ paths:
           description: Bad Request
         401:
           description: Username or password is incorrect
-
+    delete:
+      tags:
+      - "Authentication"
+      summary: delete this token
+      responses:
+        205:
+          description: Logout sucess and client should reset content
+        400:
+          description: Bad Request
+        401:
+          description: Username or password is incorrect
+        504:
+          description: All school server is not alive
+  /oauth/token/all:
+    delete:
+      tags:
+      - "Authentication"
+      summary: delete all token
+      responses:
+        205:
+          description: Logout sucess and client should reset content
+        400:
+          description: Bad Request
+        401:
+          description: Username or password is incorrect
+          
   /server/info:
     get:
       tags:
@@ -1432,4 +1457,4 @@ components:
     JSON-Web-Token:
       type: apiKey
       in: header
-      name: Authorization
+      name: Authorization    

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -963,12 +963,6 @@ paths:
         - JSON-Web-Token: []
       parameters: 
       - in: query
-        name: "campus"
-        description: "1=建工  /2=燕巢 /3=第一 /4=楠梓 /5=旗津 "
-        schema:
-            type: integer
-            format: int64
-      - in: query
         name: "roomId"
         description: "like A001..."
         schema:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -51,32 +51,7 @@ paths:
           description: Username or password is incorrect
         504:
           description: All school server is not alive
-    delete:
-      tags:
-      - "Authentication"
-      summary: delete this token
-      responses:
-        205:
-          description: Logout sucess and client should reset content
-        400:
-          description: Bad Request
-        401:
-          description: Username or password is incorrect
-        504:
-          description: All school server is not alive
-  /oauth/token/all:
-    delete:
-      tags:
-      - "Authentication"
-      summary: delete all token
-      responses:
-        205:
-          description: Logout sucess and client should reset content
-        400:
-          description: Bad Request
-        401:
-          description: Username or password is incorrect
-          
+
   /server/info:
     get:
       tags:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -49,8 +49,6 @@ paths:
           description: Bad Request
         401:
           description: Username or password is incorrect
-        504:
-          description: All school server is not alive
 
   /server/info:
     get:
@@ -235,14 +233,10 @@ paths:
               example: {"educationSystem": "日間部四技", "department": "資訊工程系", "className": "四資工四甲", "id": "1104112345", "name": "葉大雄","pictureUrl": "http://webap.nkust.edu.tw/nkust/stdpics/XXXXX.jpg"}
         401:
           description: Token expired or Unauthorized Access
-        404:
-          description: Page not found
         500:
           description: Internal Server Error
         503:
           description: Upstream server is timeout
-        504:
-          description: Upstream server is not alive
   /user/semesters:
     get:
       tags:
@@ -285,18 +279,12 @@ paths:
                           type: string
                           description: text
               example: {"data": [{"year": "107","value":"1","text": "107學年度第1學期"},{"year": "107","value":"2","text": "107學年度第2學期"}],"default": {"year": "107","value":"2","text": "107學年度第2學期"}}
-        400: 
-          description: Bad Request
         401:
           description: Token expired or Unauthorized Access
-        404:
-          description: Page not found
         500:
           description: Internal Server Error
         503:
           description: Upstream server is timeout
-        504:
-          description: Upstream server is not alive
   /user/midterm-alerts:
     get:
       tags:
@@ -353,18 +341,15 @@ paths:
                           type: string
                           description: text
               example: {"courses":[{"entry":"01","className":"四資工甲","title":"專業倫理","group":"01","instructors":"陳洳瑾","reason":"不認真","remark":"還是不認真"}]}
+
         400: 
           description: Bad Request
         401:
           description: Token expired or Unauthorized Access
-        404:
-          description: Page not found
         500:
           description: Internal Server Error
         503:
           description: Upstream server is timeout
-        504:
-          description: Upstream server is not alive
   /user/scores:
     get:
       tags:
@@ -439,18 +424,15 @@ paths:
                           type: integer
                           description: percentage in class
               example: {"scores":[{"title":"專業倫理","units":"1.0","hours":"1.0","required":"【必修】","at":"【學期】","middleScore":"*","finalScore":"96.00","remark":""},{"title":"核心通識(三)-現今科技議題","units":"2.0","hours":"2.0","required":"【必修】","at":"【學期】","middleScore":"*","finalScore":"69.00","remark":""}],"detail":{"conduct":82,"average":39,"classRank":"57/57","classPercentage":100}}
+
         400: 
           description: Bad Request
         401:
           description: Token expired or Unauthorized Access
-        404:
-          description: Page not found
         500:
           description: Internal Server Error
         503:
           description: Upstream server is timeout
-        504:
-          description: Upstream server is not alive
   /user/coursetable:
     get:
       tags:
@@ -563,19 +545,15 @@ paths:
                         items:
                           type: string
                           description: show in forntend 
-              example: {"courses":[{"code":"0430","title":"區塊鏈技術與應用","className":"碩資工一甲","group":"01","units":"3.0","hours":"3.0","required":"【選修】","at":"【學期】","times":"(四)5-7","location":{"building":"","room":"育305"},"instructors":["鐘文鈺"]},{"code":"0431","title":"高等資料庫","className":"碩資工一甲","group":"01","units":"3.0","hours":"3.0","required":"【選修】","at":"【學期】","times":"(二)5-7","location":{"building":"","room":"育302"},"instructors":["楊孟翰"]},{"code":"0434","title":"區塊鏈技術與應用","className":"碩資工一甲","group":"01","units":"3.0","hours":"3.0","required":"【選修】","at":"【學期】","times":"(四)2-4","location":{"building":"","room":"育302"},"instructors":["楊孟翰"]}],"coursetable":{"Thursday":[{"title":"區塊鏈技術與應用","date":{"startTime":"09:10","endTime":"10:00","section":"第2節"},"location":{"building":"","room":"育302"},"instructors":["蕭淳元"]},{"title":"區塊鏈技術與應用","date":{"startTime":"10:10","endTime":"11:00","section":"第3節"},"location":{"building":"","room":"育302"},"instructors":["蕭淳元"]},{"title":"區塊鏈技術與應用","date":{"startTime":"11:10","endTime":"12:00","section":"第4節"},"location":{"building":"","room":"育302"},"instructors":["蕭淳元"]},{"title":"圖形理論","date":{"startTime":"13:30","endTime":"14:20","section":"第5節"},"location":{"building":"","room":"育305"},"instructors":["鐘文鈺"]},{"title":"圖形理論","date":{"startTime":"14:30","endTime":"15:20","section":"第6節"},"location":{"building":"","room":"育305"},"instructors":["鐘文鈺"]},{"title":"圖形理論","date":{"startTime":"15:30","endTime":"16:20","weekday":"R","section":"第7節"},"location":{"building":"","room":"育305"},"instructors":["鐘文鈺"]}],"Tuesday":[{"title":"高等資料庫","date":{"startTime":"13:30","endTime":"14:20","section":"第5節"},"location":{"building":"","room":"育302"},"instructors":["楊孟翰"]},{"title":"高等資料庫","date":{"startTime":"14:30","endTime":"15:20","section":"第6節"},"location":{"building":"","room":"育302"},"instructors":["楊孟翰"]},{"title":"高等資料庫","date":{"startTime":"15:30","endTime":"16:20","section":"第7節"},"location":{"building":"","room":"育302"},"instructors":["楊孟翰"]}],"timeCodes":["第M節","第1節","第2節","第3節","第4節","第A節","第5節","第6節","第7節","第8節","第9節","第10節","第11節","第12節","第13節"]}}
+              example: {"courses":[{"code":"0430","title":"區塊鏈技術與應用","className":"碩資工一甲","group":"01","units":"3.0","hours":"3.0","required":"【選修】","at":"【學期】","times":"(四)5-7","location":{"room":"育305"},"instructors":["鐘文鈺"]},{"code":"0431","title":"高等資料庫","className":"碩資工一甲","group":"01","units":"3.0","hours":"3.0","required":"【選修】","at":"【學期】","times":"(二)5-7","location":{"room":"育302"},"instructors":["楊孟翰"]},{"code":"0434","title":"區塊鏈技術與應用","className":"碩資工一甲","group":"01","units":"3.0","hours":"3.0","required":"【選修】","at":"【學期】","times":"(四)2-4","location":{"room":"育302"},"instructors":["楊孟翰"]}],"coursetable":{"Thursday":[{"title":"區塊鏈技術與應用","date":{"startTime":"09:10","endTime":"10:00","section":"第2節"},"location":{"room":"育302"},"instructors":["蕭淳元"]},{"title":"區塊鏈技術與應用","date":{"startTime":"10:10","endTime":"11:00","section":"第3節"},"location":{"room":"育302"},"instructors":["蕭淳元"]},{"title":"區塊鏈技術與應用","date":{"startTime":"11:10","endTime":"12:00","section":"第4節"},"location":{"room":"育302"},"instructors":["蕭淳元"]},{"title":"圖形理論","date":{"startTime":"13:30","endTime":"14:20","section":"第5節"},"location":{"room":"育305"},"instructors":["鐘文鈺"]},{"title":"圖形理論","date":{"startTime":"14:30","endTime":"15:20","section":"第6節"},"location":{"room":"育305"},"instructors":["鐘文鈺"]},{"title":"圖形理論","date":{"startTime":"15:30","endTime":"16:20","weekday":"R","section":"第7節"},"location":{"room":"育305"},"instructors":["鐘文鈺"]}],"Tuesday":[{"title":"高等資料庫","date":{"startTime":"13:30","endTime":"14:20","section":"第5節"},"location":{"room":"育302"},"instructors":["楊孟翰"]},{"title":"高等資料庫","date":{"startTime":"14:30","endTime":"15:20","section":"第6節"},"location":{"room":"育302"},"instructors":["楊孟翰"]},{"title":"高等資料庫","date":{"startTime":"15:30","endTime":"16:20","section":"第7節"},"location":{"room":"育302"},"instructors":["楊孟翰"]}],"timeCodes":["第M節","第1節","第2節","第3節","第4節","第A節","第5節","第6節","第7節","第8節","第9節","第10節","第11節","第12節","第13節"]}}
         400: 
           description: Bad Request
         401:
           description: Token expired or Unauthorized Access
-        404:
-          description: Page not found
         500:
           description: Internal Server Error
         503:
           description: Upstream server is timeout
-        504:
-          description: Upstream server is not alive
   /user/reward-and-penalty:
     get:
       tags:
@@ -627,14 +605,10 @@ paths:
           description: Bad Request
         401:
           description: Token expired or Unauthorized Access
-        404:
-          description: Page not found
         500:
           description: Internal Server Error
         503:
           description: Upstream server is timeout
-        504:
-          description: Upstream server is not alive
   /user/graduation-threshold:
     get:
       tags:
@@ -690,17 +664,13 @@ paths:
                         score:
                           type: integer
                           description: class of score
-              example: {"data": {"name":"葉大雄","className":"四資工四甲","id":"1103412345"}, "englishPass": "通過", "englishClassPass": "及格通過", "internships": [{"year":"107","semester":"4","code":"0049","name":"校外實務實習(一)","score":85}]}
+              example: {"data": {"name":"葉大雄","className":"四資工四甲","id":"1103412345"}, "englishPass": "通過", "englishClassPass": "及格通過"}
         401:
           description: Token expired or Unauthorized Access
-        404:
-          description: Page not found
         500:
           description: Internal Server Error
         503:
           description: Upstream server is timeout
-        504:
-          description: Upstream server is not alive
   /bus/timetables:
     get:
       tags:
@@ -979,14 +949,10 @@ paths:
           description: Bad Request
         401:
           description: Token expired or Unauthorized Access
-        404:
-          description: Page not found
         500:
           description: Internal Server Error
         503:
           description: Upstream server is timeout
-        504:
-          description: Upstream server is not alive 
   /user/empty-room/info:
     get:
       tags:
@@ -1103,14 +1069,10 @@ paths:
           description: Bad Request
         401:
           description: Token expired or Unauthorized Access
-        404:
-          description: Page not found
         500:
           description: Internal Server Error
         503:
           description: Upstream server is timeout
-        504:
-          description: Upstream server is not alive 
   /leaves:
     get:
       tags:


### PR DESCRIPTION
# #3 

**這PR只處理User部分和Auth部分**

移除API
---
[DELETE] /oauth/token 
[DELETE] /oauth/token/all
如果要實踐這2個功能
需要再多儲存使用者目前存活的token等等，在每次登入除了驗證完JWT
還要多做這token是不是已經被刪除了
太過多餘且JWT能做到過期，所以移除這2個API

Status code
---
404
User 部分的status code
都有確定的url了哪來的404 

504 
學校就算系統維護，也會回200
也沒有太多資料能判斷學校的回覆內容
如果要判斷學校伺服器狀態，後續從server/info獲得
發生錯誤使用500 / 503 才是

格式
---

course table 格式
目前課表沒有"建築物“ 所以移除，只留下room
如後續學校有更新，那再來更新建築物

畢業門檻
目前從webap 畢業門檻沒辦法顯示 (學校前端問題)
查詢後發現校外實習沒有出現，目前先留下個人資料以及英文門檻

GET Query String
---

查詢教室課表(empty-room)
不需要校區參數，故移除


