### PR TITLE
請假證明 副檔名判斷缺失

### DIFF
--- a/src/view/leave.py
+++ b/src/view/leave.py
@@ -95,7 +95,7 @@ class leave_submit:
         parser.data_received(convert_lowercase_mutlipart(req.stream.read()))
         # check data
         if leave_proof_image_bytes != None:
-            if leave_proof_image_bytes.multipart_filename[-3:] not in ['png', 'jpg', 'jpeg', 'PNG', "JPG", "JPEG"]:
+            if (leave_proof_image_bytes.multipart_filename[-3:] not in ['png', 'jpg', 'PNG', "JPG"]) and (leave_proof_image_bytes.multipart_filename[-4:] not in ["jpeg", "JPEG"]):
                 raise falcon.HTTPBadRequest(
                     code=401,
                     description='file type not support')


### PR DESCRIPTION
原本只檢查末3碼
會沒辦法檢查到`jpeg`