### PR TITLE
修復學期成績解析造成500的問題

### DIFF
--- a/src/cache/parse.py
+++ b/src/cache/parse.py
@@ -133,10 +133,12 @@ def scores(html):
     detail = {
         "conduct": float(total[0][5::]) if not None else 0.0,
         "average": float(total[1][4::]) if not None else 0.0,
-        "classRank": total[2][8::],
-        "classPercentage": float(total[3][7:-1]) if not None else 0.0
+        "classRank": total[2][8::]
     }
-
+    try:
+        detail["classPercentage"] = float(total[3][7:-1]) if not None else 0.0
+    except ValueError:
+        detail["classPercentage"] = 0.0
     res = {
         "scores": scores_list,
         "detail": detail


### PR DESCRIPTION
#72 
學校移除了學期百分比造成爬蟲出錯

畢竟是三大鍵的功能，認為較緊急，我也沒機器可以開server提供測試了

先行放到正式版的機器上。