### PR TITLE
刪除時刻表cache過快#101

### DIFF
--- a/src/cache/bus_cache.py
+++ b/src/cache/bus_cache.py
@@ -197,12 +197,6 @@ def bus_reserve_book(username, kid, action):
             if result.get("busTime"):
                 book_time = datetime.fromtimestamp(
                     int(result.get("busTime"))/1000)
-                for key in red_string.scan_iter(
-                        'bus_timetable_{year}_{month}_{day}'.format(
-                        year=book_time.year,
-                        month=book_time.month,
-                        day=book_time.day)):
-                    red_string.delete(key)
                 # update new main timetable
                 pool.apply_async(func=get_and_update_timetable_cache, args=(
                     session, book_time.year, book_time.month, book_time.day,))


### PR DESCRIPTION
順序問題

在測試的時候沒有快速請求的測試，使用才發現

原本
平均時刻表請求約1.5s
如果低於1.5秒做第二次請求，這中間會有沒cache的狀態

so..
不刪除cache 直接set去更新cache 